### PR TITLE
fix for query like App.Item.find({'field': 'value'})

### DIFF
--- a/packages/ember-data-tastypie-adapter/lib/tastypie_adapter.js
+++ b/packages/ember-data-tastypie-adapter/lib/tastypie_adapter.js
@@ -131,7 +131,8 @@ DS.DjangoTastypieAdapter = DS.RESTAdapter.extend({
   },
 
   didFindQuery: function(store, type, json, recordArray) {
-    recordArray.load(json.objects);
+    var data = store.loadMany(type, json.objects);
+    recordArray.load(data);
   },
 
   buildURL: function(record, suffix) {


### PR DESCRIPTION
Pass proper data to AdapterPopulatedRecordArray 
