### PR TITLE
Add support for embedded = 'always'

### DIFF
--- a/packages/ember-data-tastypie-adapter/lib/tastypie_serializer.js
+++ b/packages/ember-data-tastypie-adapter/lib/tastypie_serializer.js
@@ -49,7 +49,9 @@ DS.DjangoTastypieSerializer = DS.JSONSerializer.extend({
         serializedValues.push(item.serialize());
       } else {
         id = get(item, self.primaryKey(item));
-        serializedValues.push(self.getItemUrl(relationship, id));
+        if (!Ember.isNone(id)) {
+          serializedValues.push(self.getItemUrl(relationship, id));
+        }
       }
     });
 


### PR DESCRIPTION
This pull request adds support for posting embedded relations back to the server. It's a quite small change to the serializer to check if embedded = 'always' and if so add the serialized related object instead of the url.
