### PR TITLE
implement sinceQuery to pass parameters of filtering

### DIFF
--- a/packages/ember-data-tastypie-adapter/lib/tastypie_adapter.js
+++ b/packages/ember-data-tastypie-adapter/lib/tastypie_adapter.js
@@ -167,20 +167,32 @@ DS.DjangoTastypieAdapter = DS.RESTAdapter.extend({
      from which the offset will be extrated for the next request
   */
   sinceQuery: function(since) {
+
+
     var offsetParam,
         query;
 
     query = {};
 
     if (!!since) {
-      offsetParam = since.match(/offset=(\d+)/);
-      offsetParam = (!!offsetParam && !!offsetParam[1]) ? offsetParam[1] : null;
-      query.offset = offsetParam;
+      var querybuild = {};
+
+      var test = since.split("/?");
+      var parans = test[1].split("&");
+
+      for(x = 0; x<parans.length;x++){
+        var test2  = parans[x].split("=");
+        querybuild[test2[0]]=test2[1];
+
+
+      }
+      //offsetParam = since.match(/offset=(\d+)/);
+      //offsetParam = (!!offsetParam && !!offsetParam[1]) ? offsetParam[1] : null;
+      query = querybuild;
     }
 
     return offsetParam ? query : null;
   },
-
   removeTrailingSlash: function(url) {
     if (url.charAt(url.length -1) === '/') {
       return url.slice(0, -1);


### PR DESCRIPTION
i did this implementation because when i use a filtering like :

```
App.ReadsRoute = Ember.Route.extend({
   model: function() {
      return App.Read.find({is_read : false});

  },

  events: {
    more: function() {
      // NOTE: in the default configuration where the server API sends
      // results paginated, this will automatically load next page.
      return App.Read.find();
    },

    openRead: function(read) {
      this.transitionToAnimated('reads.show', {main: 'slideLeft'}, read);
    }
  }
});
```

the return for model works but on more it just implements offset and eliminate the filter 

in the case of using the filtering also on the more return is even worst because sinceQuery is not even called

so the idea here was use the url generated by tastypie to keep searching the next pages instead of just increment offset and in that way keeping filtering used on the first query 

i don't know if is the best idea any help is welcome.

I'm pretty new in python!!!!

obs: when i do with the more and model returns without any filtering both with my implementation and without works well and with my implementation + filtering ember still not loading the data properly but at least is looking at the proper url now 
