### PR TITLE
Fix for #36

### DIFF
--- a/packages/ember-data-tastypie-adapter/lib/tastypie_serializer.js
+++ b/packages/ember-data-tastypie-adapter/lib/tastypie_serializer.js
@@ -209,7 +209,7 @@ DS.DjangoTastypieSerializer = DS.RESTSerializer.extend({
           return data;
         });
       } else {
-        json[key] = get(record, relationship.key).map(function (next){
+        json[key] = get(record, 'data.' + relationship.key).map(function (next) {
           return this.relationshipToResourceUri(relationship, next);
         }, this);
       }


### PR DESCRIPTION
SerializeHasMany doesn't handle promises. Getting the IDs from `data` avoids the promise and also avoids having to fetch the related records before being able to save a reference to them.
