### PR TITLE
Revert "Fix for #36"

### DIFF
--- a/packages/ember-data-tastypie-adapter/lib/tastypie_serializer.js
+++ b/packages/ember-data-tastypie-adapter/lib/tastypie_serializer.js
@@ -209,7 +209,7 @@ DS.DjangoTastypieSerializer = DS.RESTSerializer.extend({
           return data;
         });
       } else {
-        json[key] = get(record, 'data.' + relationship.key).map(function (next) {
+        json[key] = get(record, relationship.key).map(function (next){
           return this.relationshipToResourceUri(relationship, next);
         }, this);
       }


### PR DESCRIPTION
Reverts escalant3/ember-data-tastypie-adapter#37

Some of the tests are failing with `'undefined' is not an object (evaluating 'get(record, 'data.' + relationship.key).map')`. I need more time to test everything is okay...
